### PR TITLE
 Modified nodeset_compiler to reduce the size of generated function 

### DIFF
--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -286,7 +286,7 @@ _UA_END_DECLS
     # having a single huge function
     beginFunctionCounter = 0
     finishFunctionCounter = functionNumber
-    numberOfCallsForHelper = 1000
+    numberOfCallsForHelper = 200
     # The total number of function calls is functionNumber by two (one
     # begin, and one finish)
     helperNumber = int(math.ceil(2*functionNumber/float(numberOfCallsForHelper)))


### PR DESCRIPTION
Before this change, with NS0 full, the `ua_namespace0.c` generated file contained the following function called `ua_namespace0` that contained ~7400 lines : 
~~~c
UA_StatusCode ua_namespace0(UA_Server *server) {
UA_StatusCode retVal = UA_STATUSCODE_GOOD;
/* Use namespace ids generated by the server */
UA_UInt16 ns[1];
ns[0] = UA_Server_addNamespace(server, "http://opcfoundation.org/UA/");
retVal |= function_ua_namespace0_0_begin(server, ns);
retVal |= function_ua_namespace0_1_begin(server, ns);
retVal |= function_ua_namespace0_2_begin(server, ns);
retVal |= function_ua_namespace0_3_begin(server, ns);
retVal |= function_ua_namespace0_4_begin(server, ns);
retVal |= function_ua_namespace0_5_begin(server, ns);
//  omitted ~7300 lines 
retVal |= function_ua_namespace0_3_finish(server, ns);
retVal |= function_ua_namespace0_2_finish(server, ns);
retVal |= function_ua_namespace0_1_finish(server, ns);
retVal |= function_ua_namespace0_0_finish(server, ns);
return retVal;
}
~~~
after this change, the `ua_namespace0` function is actually decomposed in several helper function, each of one contained a maximum of 1000 statements, see: 
~~~c
UA_StatusCode ua_namespace0(UA_Server *server) {
UA_StatusCode retVal = UA_STATUSCODE_GOOD;
/* Use namespace ids generated by the server */
UA_UInt16 ns[1];
ns[0] = UA_Server_addNamespace(server, "http://opcfoundation.org/UA/");
retVal |= ua_namespace0_helper_0(server, ns);
retVal |= ua_namespace0_helper_1(server, ns);
retVal |= ua_namespace0_helper_2(server, ns);
retVal |= ua_namespace0_helper_3(server, ns);
retVal |= ua_namespace0_helper_4(server, ns);
retVal |= ua_namespace0_helper_5(server, ns);
retVal |= ua_namespace0_helper_6(server, ns);
retVal |= ua_namespace0_helper_7(server, ns);
return retVal;
}
~~~