### PR TITLE
Add support for historizing specified as an attribute of the UAVariable tag

### DIFF
--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -259,6 +259,8 @@ class VariableNode(Node):
                 self.dataType = RefOrAlias(av)
             elif  at == "ArrayDimensions":
                 self.arrayDimensions = av.split(",")
+            elif at == "Historizing":
+                self.historizing = "false" not in av.lower()
 
         for x in xmlelement.childNodes:
             if x.nodeType != x.ELEMENT_NODE:


### PR DESCRIPTION
I did not check the official specification for now, but it seems that `Historizing` can also be specified as an attribute of the `UAVariable` tag. For an example of such use, search for the `Historizing="true"` string in https://opcfoundation.org/UA/schemas/AutoID/1.0/Opc.Ua.AutoID.NodeSet2.xml . This attribute is currently ignored by open62541's node code generator, and this PR fix this. 

This ensure that the line `attr->historizing = true` is correctly generated for the nodes for which `Historizing="true"`. 