### PR TITLE
Reduce numberOfCallsForHelper parameter to 100

### DIFF
--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -286,7 +286,7 @@ _UA_END_DECLS
     # having a single huge function
     beginFunctionCounter = 0
     finishFunctionCounter = functionNumber
-    numberOfCallsForHelper = 200
+    numberOfCallsForHelper = 100
     # The total number of function calls is functionNumber by two (one
     # begin, and one finish)
     helperNumber = int(math.ceil(2*functionNumber/float(numberOfCallsForHelper)))


### PR DESCRIPTION
As discussed in  https://github.com/iit-danieli-joint-lab/open62541/pull/2#issuecomment-464517546 , the speed of compilation is ~40 s on my laptop for both numberOfCallsForHelper  set to 200 or 100. However, when cross compiling I experienced internal compilers error if numberOfCallsForHelper are set to 200, but everything works fine if I set this parameter to 100. 